### PR TITLE
Bump vcpkg protobuf

### DIFF
--- a/vcpkg_info.txt
+++ b/vcpkg_info.txt
@@ -1,2 +1,2 @@
 https://github.com/microsoft/vcpkg.git
-38752e29c2b60ea522d629a40b57b95606e16715
+ad2933e97e7f6d2e2bece2a7a372be7a6833f28c


### PR DESCRIPTION
New protobuf fixes some CMake bugs.

If you want to regularly build from source, I would suggest using `ccache`(and upping the cache size limit to maybe 20GB if you want to build multiple LLVM versions and possibly debug versions as well) to speed up compilation of packages that haven't been upgraded:

```
export CMAKE_C_COMPILER_LAUNCHER="$(which ccache)"
export CMAKE_CXX_COMPILER_LAUNCHER="$(which ccache)"
./build_dependencies.sh --release llvm-10
```

The reason for needing to rebuild everything is because vcpkg hashes all of the script files used to process each package definition and encodes this when building and caching the results. This is to ensure that there are no breaking changes between script modifications when building new packages or reusing installed packages.

I'll add this info to the README eventually.

After CI passes and this is merged to master, we'll want to cut a release.