### PR TITLE
Use clang as the default compiler if available, and fix the protoc permission issue

### DIFF
--- a/build_dependencies.sh
+++ b/build_dependencies.sh
@@ -73,12 +73,20 @@ msg " " "$@"
   cd "${repo_dir}"
   (
     set -x
+
+    if type clang >/dev/null 2>&1; then
+        export CC="${CC:-$(which clang)}"
+        export CXX="${CXX:-$(which clang++)}"
+    fi
+
     # TODO: Better way to remove all unspecified packages that we're about to
     # install for specified triplet? Need this because different LLVM versions
     # conflict when installed at the same time
     rm -rf "${vcpkg_dir:?}/installed" || true
     "${vcpkg_dir}/vcpkg" install "${extra_vcpkg_args[@]}" '@overlays.txt' '@dependencies.txt' "$@"
     "${vcpkg_dir}/vcpkg" upgrade "${extra_vcpkg_args[@]}" '@overlays.txt' --no-dry-run
+
+    find "${vcpkg_dir}"/installed/*/tools/protobuf/ -type f -exec chmod 755 {} +
   )
 )
 


### PR DESCRIPTION
Issue:

1. With the new vcpkg build system, g++ 10.2.0 has trouble building
   llvm-10, generating an error `/usr/bin/ld.gold: internal error in open,
   at /build/binutils/src/binutils-gdb/gold/descriptors.cc:99` while
   linking `lib/libclang-cpp.so.10`. So it may be advisable to use Clang
   as the default compiler in the build script, in addition to setting
   it in the dockerfile.
2. The permission of the `protoc` tool built by vcpkg is 774. If we
   follow the typical way of building software by building it without
   privilege and installing it with privilege, there will be a
   "permission denied" error when we are building McSema.