### PR TITLE
Bump z3 to python3

### DIFF
--- a/ports/z3/portfile.cmake
+++ b/ports/z3/portfile.cmake
@@ -1,9 +1,9 @@
 #NOTE(Artem): Modified not to fail on arm64
 vcpkg_fail_port_install(ON_TARGET "UWP")
 
-vcpkg_find_acquire_program(PYTHON2)
-get_filename_component(PYTHON2_DIR "${PYTHON2}" DIRECTORY)
-vcpkg_add_to_path("${PYTHON2_DIR}")
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR "${PYTHON3}" DIRECTORY)
+vcpkg_add_to_path("${PYTHON3_DIR}")
 
 vcpkg_from_github(
   OUT_SOURCE_PATH SOURCE_PATH


### PR DESCRIPTION
Make z3 use py3 to avoid having an un-needed dependency on py2. This change is already in the windows branch, but running into issues where it would be helpful on its own.