### PR TITLE
Revert to using MacOS 10.15 runner with XCode 12.4

### DIFF
--- a/.github/workflows/vcpkg_ci_mac.yml
+++ b/.github/workflows/vcpkg_ci_mac.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - { runner: 'macos-11.0', xcode: '12.2.0' }
+          - { runner: 'macos-10.15', xcode: '12.4' }
         llvm: [
           'llvm-11'
           ]
@@ -68,10 +68,10 @@ jobs:
         env:
           NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: maxim-lobanov/setup-xcode@v1.2.1
-        # 'latest-stable' has some bugs... Keep explicit for now
-        with:
-          xcode-version: ${{ matrix.os.xcode }}
+      - name: Select the XCode version
+        run: |
+          echo "Selecting XCode Version ${{ matrix.os.xcode }}"
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.os.xcode }}.app/Contents/Developer
 
       - name: Read vcpkg Info
         id: vcpkg_info


### PR DESCRIPTION
MacOS 11 runners are unstable and often fail to start.

Updated XCode to latest stable version