### PR TITLE
Build LLVM compiler-rt by default for toolchain sanitizer support

### DIFF
--- a/ports/llvm-10/CONTROL
+++ b/ports/llvm-10/CONTROL
@@ -3,8 +3,8 @@ Version: 10.0.1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
-Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Build-Depends: llvm-vcpkg-common, llvm-10[core, compiler-rt] (linux|osx)
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-10/CONTROL
+++ b/ports/llvm-10/CONTROL
@@ -4,7 +4,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-11/CONTROL
+++ b/ports/llvm-11/CONTROL
@@ -3,8 +3,8 @@ Version: 11.0.1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
-Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Build-Depends: llvm-vcpkg-common, llvm-11[core, compiler-rt] (linux|osx)
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-11/CONTROL
+++ b/ports/llvm-11/CONTROL
@@ -4,7 +4,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-12/CONTROL
+++ b/ports/llvm-12/CONTROL
@@ -3,8 +3,8 @@ Version: 12.0.0
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
-Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Build-Depends: llvm-vcpkg-common, llvm-12[core, compiler-rt] (linux|osx)
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-12/CONTROL
+++ b/ports/llvm-12/CONTROL
@@ -4,7 +4,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-9/0010-compiler-rt-glibc-2.31.patch
+++ b/ports/llvm-9/0010-compiler-rt-glibc-2.31.patch
@@ -1,0 +1,35 @@
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.cc
+@@ -1126,8 +1126,9 @@
+ CHECK_SIZE_AND_OFFSET(ipc_perm, gid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, cuid);
+ CHECK_SIZE_AND_OFFSET(ipc_perm, cgid);
+-#if !defined(__aarch64__) || !SANITIZER_LINUX || __GLIBC_PREREQ (2, 21)
+-/* On aarch64 glibc 2.20 and earlier provided incorrect mode field.  */
++#if !SANITIZER_LINUX || __GLIBC_PREREQ (2, 31)
++/* glibc 2.30 and earlier provided 16-bit mode field instead of 32-bit
++   on many architectures.  */
+ CHECK_SIZE_AND_OFFSET(ipc_perm, mode);
+ #endif
+ 
+diff --git a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+--- a/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
++++ b/compiler-rt/lib/sanitizer_common/sanitizer_platform_limits_posix.h
+@@ -214,15 +214,8 @@
+     unsigned short __seq;
+     unsigned long long __unused1;
+     unsigned long long __unused2;
+-#elif defined(__mips__) || defined(__aarch64__) || defined(__s390x__)
+-    unsigned int mode;
+-    unsigned short __seq;
+-    unsigned short __pad1;
+-    unsigned long __unused1;
+-    unsigned long __unused2;
+ #else
+-    unsigned short mode;
+-    unsigned short __pad1;
++    unsigned int mode;
+     unsigned short __seq;
+     unsigned short __pad2;
+ #if defined(__x86_64__) && !defined(_LP64)

--- a/ports/llvm-9/CONTROL
+++ b/ports/llvm-9/CONTROL
@@ -5,7 +5,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-9/CONTROL
+++ b/ports/llvm-9/CONTROL
@@ -4,8 +4,8 @@ Port-Version: 1
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
-Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, compiler-rt, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Build-Depends: llvm-vcpkg-common, llvm-9[core, compiler-rt] (linux|osx)
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.

--- a/ports/llvm-9/portfile.cmake
+++ b/ports/llvm-9/portfile.cmake
@@ -18,6 +18,7 @@ vcpkg_from_github(
         0007-remove-FindZ3.cmake.patch
         0008-fix-FindZ3.cmake.patch
         0009-clang-sys-include-dir-path.patch
+        0010-compiler-rt-glibc-2.31.patch
         0020-fix-vs2019-v16.6.patch
 )
 


### PR DESCRIPTION
closes #715 