### PR TITLE
llvm12 build support

### DIFF
--- a/ports/llvm-10/CONTROL
+++ b/ports/llvm-10/CONTROL
@@ -4,7 +4,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.
@@ -125,3 +125,6 @@ Description: Build libcxx runtime
 
 Feature: libcxxabi
 Description: Build libcxxabi runtime
+
+Feature: enable-eh
+Description: Build LLVM with exception handler turned on.

--- a/ports/llvm-11/CONTROL
+++ b/ports/llvm-11/CONTROL
@@ -4,7 +4,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.
@@ -135,3 +135,6 @@ Description: Build libcxx runtime
 
 Feature: libcxxabi
 Description: Build libcxxabi runtime
+
+Feature: enable-eh
+Description: Build LLVM with exception handler turned on.

--- a/ports/llvm-12/0001-fix-install-paths.patch
+++ b/ports/llvm-12/0001-fix-install-paths.patch
@@ -1,0 +1,112 @@
+diff --git a/clang/cmake/modules/CMakeLists.txt b/clang/cmake/modules/CMakeLists.txt
+index d233f552f01..26f502ad2d2 100644
+--- a/clang/cmake/modules/CMakeLists.txt
++++ b/clang/cmake/modules/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(CLANG_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/clang)
++set(CLANG_INSTALL_PACKAGE_DIR share/clang)
+ set(clang_cmake_builddir "${CMAKE_BINARY_DIR}/${CLANG_INSTALL_PACKAGE_DIR}")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ get_property(CLANG_EXPORTS GLOBAL PROPERTY CLANG_EXPORTS)
+diff --git a/flang/cmake/modules/CMakeLists.txt b/flang/cmake/modules/CMakeLists.txt
+index d233f552f01..26f502ad2d2 100644
+--- a/flang/cmake/modules/CMakeLists.txt
++++ b/flang/cmake/modules/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(FLANG_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/flang)
++set(FLANG_INSTALL_PACKAGE_DIR share/flang)
+ set(flang_cmake_builddir "${CMAKE_BINARY_DIR}/${FLANG_INSTALL_PACKAGE_DIR}")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ get_property(FLANG_EXPORTS GLOBAL PROPERTY FLANG_EXPORTS)
+diff --git a/lld/cmake/modules/CMakeLists.txt b/lld/cmake/modules/CMakeLists.txt
+index d233f552f01..26f502ad2d2 100644
+--- a/lld/cmake/modules/CMakeLists.txt
++++ b/lld/cmake/modules/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(LLD_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/lld)
++set(LLD_INSTALL_PACKAGE_DIR share/lld)
+ set(lld_cmake_builddir "${CMAKE_BINARY_DIR}/${LLD_INSTALL_PACKAGE_DIR}")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ get_property(LLD_EXPORTS GLOBAL PROPERTY LLD_EXPORTS)
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index 211f9551271..2abe3803f91 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -973,10 +973,10 @@
+   if(ARG_GEN_CONFIG)
+ 
+       ## Part 1: Extension header to be included whenever we need extension
+       #  processing.
+-      set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++      set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+       set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+       file(WRITE
+           "${llvm_cmake_builddir}/LLVMConfigExtensions.cmake"
+           "set(LLVM_STATIC_EXTENSIONS ${LLVM_STATIC_EXTENSIONS})")
+       install(FILES
+diff --git a/llvm/cmake/modules/CMakeLists.txt b/llvm/cmake/modules/CMakeLists.txt
+index 9cf22b436fa..8eeb27d1794 100644
+--- a/llvm/cmake/modules/CMakeLists.txt
++++ b/llvm/cmake/modules/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ # First for users who use an installed LLVM, create the LLVMExports.cmake file.
+diff --git a/mlir/cmake/modules/CMakeLists.txt b/mlir/cmake/modules/CMakeLists.txt
+index d233f552f01..26f502ad2d2 100644
+--- a/mlir/cmake/modules/CMakeLists.txt
++++ b/mlir/cmake/modules/CMakeLists.txt
+@@ -1,11 +1,11 @@
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(MLIR_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir)
++set(MLIR_INSTALL_PACKAGE_DIR share/mlir)
+ set(mlir_cmake_builddir "${CMAKE_BINARY_DIR}/${MLIR_INSTALL_PACKAGE_DIR}")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm)
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/${LLVM_INSTALL_PACKAGE_DIR}")
+ 
+ get_property(MLIR_EXPORTS GLOBAL PROPERTY MLIR_EXPORTS)
+diff --git a/polly/cmake/CMakeLists.txt b/polly/cmake/CMakeLists.txt
+index 211f9551271..2abe3803f91 100644
+--- a/polly/cmake/CMakeLists.txt
++++ b/polly/cmake/CMakeLists.txt
+@@ -1,7 +1,7 @@
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+ 
+-set(LLVM_INSTALL_PACKAGE_DIR "lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+-set(POLLY_INSTALL_PACKAGE_DIR "lib${LLVM_LIBDIR_SUFFIX}/cmake/polly")
++set(LLVM_INSTALL_PACKAGE_DIR share/llvm)
++set(POLLY_INSTALL_PACKAGE_DIR share/polly)
+ if (CMAKE_CONFIGURATION_TYPES)
+   set(POLLY_EXPORTS_FILE_NAME "PollyExports-$<LOWER_CASE:$<CONFIG>>.cmake")
+ else()

--- a/ports/llvm-12/0002-fix-openmp-debug.patch
+++ b/ports/llvm-12/0002-fix-openmp-debug.patch
@@ -1,0 +1,22 @@
+diff --git a/openmp/runtime/src/CMakeLists.txt b/openmp/runtime/src/CMakeLists.txt
+index 822f9ca2b825..814e25864610 100644
+--- a/openmp/runtime/src/CMakeLists.txt
++++ b/openmp/runtime/src/CMakeLists.txt
+@@ -157,7 +157,7 @@ else()
+ endif()
+ 
+ set_target_properties(omp PROPERTIES
+-  PREFIX "" SUFFIX "" OUTPUT_NAME "${LIBOMP_LIB_FILE}"
++  PREFIX "" SUFFIX "" OUTPUT_NAME "${LIBOMP_LIB_FILE}" DEBUG_POSTFIX ""
+   LINK_FLAGS "${LIBOMP_CONFIGURED_LDFLAGS}"
+   LINKER_LANGUAGE ${LIBOMP_LINKER_LANGUAGE}
+ )
+@@ -232,7 +232,7 @@ if(WIN32)
+     # Create new import library that is just the previously created one + kmp_import.cpp
+     add_library(ompimp STATIC ${LIBOMP_GENERATED_IMP_LIB} kmp_import.cpp)
+     set_target_properties(ompimp PROPERTIES
+-      PREFIX "" SUFFIX "" OUTPUT_NAME "${LIBOMP_IMP_LIB_FILE}"
++      PREFIX "" SUFFIX "" OUTPUT_NAME "${LIBOMP_IMP_LIB_FILE}" DEBUG_POSTFIX ""
+       LINKER_LANGUAGE C
+     )
+     add_dependencies(ompimp omp) # ensure generated import library is created first

--- a/ports/llvm-12/0003-fix-dr-1734.patch
+++ b/ports/llvm-12/0003-fix-dr-1734.patch
@@ -1,0 +1,14 @@
+diff --git a/llvm/include/llvm/Support/type_traits.h b/llvm/include/llvm/Support/type_traits.h
+index b7d48e8e1ad..53ba24efc00 100644
+--- a/llvm/include/llvm/Support/type_traits.h
++++ b/llvm/include/llvm/Support/type_traits.h
+@@ -177,7 +177,8 @@ class is_trivially_copyable {
+       (has_deleted_copy_assign || has_trivial_copy_assign) &&
+       (has_deleted_copy_constructor || has_trivial_copy_constructor);
+ 
+-#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE
++  // due to DR 1734, a type can be std::is_trivially_copyable but not llvm::is_trivially_copyable
++#if 0
+   static_assert(value == std::is_trivially_copyable<T>::value,
+                 "inconsistent behavior between llvm:: and std:: implementation of is_trivially_copyable");
+ #endif

--- a/ports/llvm-12/0004-fix-tools-path.patch
+++ b/ports/llvm-12/0004-fix-tools-path.patch
@@ -1,0 +1,14 @@
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index 53ba24efc00..0badcafe000 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -304,8 +304,8 @@ int main(int argc, char **argv) {
+   // Create an absolute path, and pop up one directory (we expect to be inside a
+   // bin dir).
+   sys::fs::make_absolute(CurrentPath);
+   CurrentExecPrefix =
+-      sys::path::parent_path(sys::path::parent_path(CurrentPath)).str();
++      sys::path::parent_path(sys::path::parent_path(sys::path::parent_path(CurrentPath))).str();
+ 
+   // Check to see if we are inside a development tree by comparing to possible
+   // locations (prefix style or CMake style).

--- a/ports/llvm-12/0005-remove-FindZ3.cmake.patch
+++ b/ports/llvm-12/0005-remove-FindZ3.cmake.patch
@@ -1,0 +1,116 @@
+diff --git a/llvm/cmake/modules/FindZ3.cmake b/llvm/cmake/modules/FindZ3.cmake
+deleted file mode 100644
+index 95dd37789..000000000
+--- a/llvm/cmake/modules/FindZ3.cmake
++++ /dev/null
+@@ -1,110 +0,0 @@
+-INCLUDE(CheckCXXSourceRuns)
+-
+-# Function to check Z3's version
+-function(check_z3_version z3_include z3_lib)
+-  # The program that will be executed to print Z3's version.
+-  file(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testz3.c
+-       "#include <assert.h>
+-        #include <z3.h>
+-        int main() {
+-          unsigned int major, minor, build, rev;
+-          Z3_get_version(&major, &minor, &build, &rev);
+-          printf(\"%u.%u.%u\", major, minor, build);
+-          return 0;
+-       }")
+-
+-  # Get lib path
+-  get_filename_component(z3_lib_path ${z3_lib} PATH)
+-
+-  try_run(
+-    Z3_RETURNCODE
+-    Z3_COMPILED
+-    ${CMAKE_BINARY_DIR}
+-    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/testz3.c
+-    COMPILE_DEFINITIONS -I"${z3_include}"
+-    LINK_LIBRARIES -L${z3_lib_path} -lz3
+-    RUN_OUTPUT_VARIABLE SRC_OUTPUT
+-  )
+-
+-  if(Z3_COMPILED)
+-    string(REGEX REPLACE "([0-9]*\\.[0-9]*\\.[0-9]*)" "\\1"
+-           z3_version "${SRC_OUTPUT}")
+-    set(Z3_VERSION_STRING ${z3_version} PARENT_SCOPE)
+-  endif()
+-endfunction(check_z3_version)
+-
+-# Looking for Z3 in LLVM_Z3_INSTALL_DIR
+-find_path(Z3_INCLUDE_DIR NAMES z3.h
+-  NO_DEFAULT_PATH
+-  PATHS ${LLVM_Z3_INSTALL_DIR}/include
+-  PATH_SUFFIXES libz3 z3
+-  )
+-
+-find_library(Z3_LIBRARIES NAMES z3 libz3
+-  NO_DEFAULT_PATH
+-  PATHS ${LLVM_Z3_INSTALL_DIR}
+-  PATH_SUFFIXES lib bin
+-  )
+-
+-# If Z3 has not been found in LLVM_Z3_INSTALL_DIR look in the default directories
+-find_path(Z3_INCLUDE_DIR NAMES z3.h
+-  PATH_SUFFIXES libz3 z3
+-  )
+-
+-find_library(Z3_LIBRARIES NAMES z3 libz3
+-  PATH_SUFFIXES lib bin
+-  )
+-
+-# Searching for the version of the Z3 library is a best-effort task
+-unset(Z3_VERSION_STRING)
+-
+-# First, try to check it dynamically, by compiling a small program that
+-# prints Z3's version
+-if(Z3_INCLUDE_DIR AND Z3_LIBRARIES)
+-  # We do not have the Z3 binary to query for a version. Try to use
+-  # a small C++ program to detect it via the Z3_get_version() API call.
+-  check_z3_version(${Z3_INCLUDE_DIR} ${Z3_LIBRARIES})
+-endif()
+-
+-# If the dynamic check fails, we might be cross compiling: if that's the case,
+-# check the version in the headers, otherwise, fail with a message
+-if(NOT Z3_VERSION_STRING AND (CMAKE_CROSSCOMPILING AND
+-                              Z3_INCLUDE_DIR AND
+-                              EXISTS "${Z3_INCLUDE_DIR}/z3_version.h"))
+-  # TODO: print message warning that we couldn't find a compatible lib?
+-
+-  # Z3 4.8.1+ has the version is in a public header.
+-  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
+-       z3_version_str REGEX "^#define[\t ]+Z3_MAJOR_VERSION[\t ]+.*")
+-  string(REGEX REPLACE "^.*Z3_MAJOR_VERSION[\t ]+([0-9]).*$" "\\1"
+-         Z3_MAJOR "${z3_version_str}")
+-
+-  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
+-       z3_version_str REGEX "^#define[\t ]+Z3_MINOR_VERSION[\t ]+.*")
+-  string(REGEX REPLACE "^.*Z3_MINOR_VERSION[\t ]+([0-9]).*$" "\\1"
+-         Z3_MINOR "${z3_version_str}")
+-
+-  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
+-       z3_version_str REGEX "^#define[\t ]+Z3_BUILD_NUMBER[\t ]+.*")
+-  string(REGEX REPLACE "^.*Z3_BUILD_VERSION[\t ]+([0-9]).*$" "\\1"
+-         Z3_BUILD "${z3_version_str}")
+-
+-  set(Z3_VERSION_STRING ${Z3_MAJOR}.${Z3_MINOR}.${Z3_BUILD})
+-  unset(z3_version_str)
+-endif()
+-
+-if(NOT Z3_VERSION_STRING)
+-  # Give up: we are unable to obtain a version of the Z3 library. Be
+-  # conservative and force the found version to 0.0.0 to make version
+-  # checks always fail.
+-  set(Z3_VERSION_STRING "0.0.0")
+-endif()
+-
+-# handle the QUIETLY and REQUIRED arguments and set Z3_FOUND to TRUE if
+-# all listed variables are TRUE
+-include(FindPackageHandleStandardArgs)
+-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Z3
+-                                  REQUIRED_VARS Z3_LIBRARIES Z3_INCLUDE_DIR
+-                                  VERSION_VAR Z3_VERSION_STRING)
+-
+-mark_as_advanced(Z3_INCLUDE_DIR Z3_LIBRARIES)

--- a/ports/llvm-12/0006-fix-FindZ3.cmake.patch
+++ b/ports/llvm-12/0006-fix-FindZ3.cmake.patch
@@ -1,0 +1,135 @@
+diff --git a/llvm/cmake/modules/FindZ3.cmake b/llvm/cmake/modules/FindZ3.cmake
+new file mode 100644
+index 000000000..32f6f4160
+--- /dev/null
++++ b/llvm/cmake/modules/FindZ3.cmake
+@@ -0,0 +1,115 @@
++INCLUDE(CheckCXXSourceRuns)
++
++# Function to check Z3's version
++function(check_z3_version z3_include z3_lib)
++  # Get lib path
++  get_filename_component(z3_lib_path ${z3_lib} PATH)
++
++  # Try to find a threading module in case Z3 was built with threading support.
++  # Threads are required elsewhere in LLVM, but not marked as required here because
++  # Z3 could have been compiled without threading support.
++  find_package(Threads)
++  set(z3_link_libs "-lz3" "${CMAKE_THREAD_LIBS_INIT}")
++
++  try_run(
++    Z3_RETURNCODE
++    Z3_COMPILED
++    ${CMAKE_BINARY_DIR}
++    ${CMAKE_SOURCE_DIR}/cmake/modules/testz3.cpp
++    COMPILE_DEFINITIONS -I"${z3_include}"
++    LINK_LIBRARIES -L${z3_lib_path} ${z3_link_libs}
++    RUN_OUTPUT_VARIABLE SRC_OUTPUT
++  )
++
++  if(Z3_COMPILED)
++    string(REGEX REPLACE "([0-9]*\\.[0-9]*\\.[0-9]*)" "\\1"
++           z3_version "${SRC_OUTPUT}")
++    set(Z3_VERSION_STRING ${z3_version} PARENT_SCOPE)
++  endif()
++endfunction(check_z3_version)
++
++# Looking for Z3 in LLVM_Z3_INSTALL_DIR
++find_path(Z3_INCLUDE_DIR NAMES z3.h
++  NO_DEFAULT_PATH
++  PATHS ${LLVM_Z3_INSTALL_DIR}/include
++  PATH_SUFFIXES libz3 z3
++  )
++
++find_library(Z3_LIBS NAMES z3 libz3
++  NO_DEFAULT_PATH
++  PATHS ${LLVM_Z3_INSTALL_DIR}
++  PATH_SUFFIXES lib bin
++  )
++
++# If Z3 has not been found in LLVM_Z3_INSTALL_DIR look in the default directories
++find_path(Z3_INCLUDE_DIR NAMES z3.h
++  PATH_SUFFIXES libz3 z3
++  )
++
++find_library(Z3_LIBS NAMES z3 libz3
++  PATH_SUFFIXES lib bin
++  )
++
++# Searching for the version of the Z3 library is a best-effort task
++unset(Z3_VERSION_STRING)
++
++# First, try to check it dynamically, by compiling a small program that
++# prints Z3's version
++if(Z3_INCLUDE_DIR AND Z3_LIBS)
++  # We do not have the Z3 binary to query for a version. Try to use
++  # a small C++ program to detect it via the Z3_get_version() API call.
++  check_z3_version(${Z3_INCLUDE_DIR} ${Z3_LIBS})
++endif()
++
++# If the dynamic check fails, we might be cross compiling: if that's the case,
++# check the version in the headers, otherwise, fail with a message
++if(EXISTS "${Z3_INCLUDE_DIR}/z3_version.h" AND (NOT Z3_VERSION_STRING OR
++                              (CMAKE_CROSSCOMPILING AND
++                              Z3_INCLUDE_DIR)))
++  # TODO: print message warning that we couldn't find a compatible lib?
++
++  # Z3 4.8.1+ has the version is in a public header.
++  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
++       z3_version_str REGEX "^#define[\t ]+Z3_MAJOR_VERSION[\t ]+.*")
++  string(REGEX REPLACE "^.*Z3_MAJOR_VERSION[\t ]+([0-9]).*$" "\\1"
++         Z3_MAJOR "${z3_version_str}")
++
++  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
++       z3_version_str REGEX "^#define[\t ]+Z3_MINOR_VERSION[\t ]+.*")
++  string(REGEX REPLACE "^.*Z3_MINOR_VERSION[\t ]+([0-9]).*$" "\\1"
++         Z3_MINOR "${z3_version_str}")
++
++  file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
++       z3_version_str REGEX "^#define[\t ]+Z3_BUILD_NUMBER[\t ]+.*")
++  string(REGEX REPLACE "^.*Z3_BUILD_NUMBER[\t ]+([0-9]).*$" "\\1"
++         Z3_BUILD "${z3_version_str}")
++
++  set(Z3_VERSION_STRING ${Z3_MAJOR}.${Z3_MINOR}.${Z3_BUILD})
++  unset(z3_version_str)
++endif()
++
++if(NOT Z3_VERSION_STRING)
++  # Give up: we are unable to obtain a version of the Z3 library. Be
++  # conservative and force the found version to 0.0.0 to make version
++  # checks always fail.
++  set(Z3_VERSION_STRING "0.0.0")
++endif()
++
++# handle the QUIETLY and REQUIRED arguments and set Z3_FOUND to TRUE if
++# all listed variables are TRUE
++include(FindPackageHandleStandardArgs)
++FIND_PACKAGE_HANDLE_STANDARD_ARGS(Z3
++                                  REQUIRED_VARS Z3_LIBS Z3_INCLUDE_DIR
++                                  VERSION_VAR Z3_VERSION_STRING)
++if(Z3_FOUND AND NOT TARGET Z3)
++  add_library(Z3 UNKNOWN IMPORTED)
++  set_target_properties(Z3 PROPERTIES
++    INTERFACE_INCLUDE_DIRECTORIES "${Z3_INCLUDE_DIR}"
++    IMPORTED_LOCATION "${Z3_LIBS}"
++  )
++  set(Z3_LIBRARIES "Z3")
++  set(THREADS_PREFER_PTHREAD_FLAG ON)
++  find_package(Threads REQUIRED)
++  target_link_libraries(Z3 INTERFACE Threads::Threads)
++endif()
++mark_as_advanced(Z3_INCLUDE_DIR Z3_LIBS Z3_LIBRARIES)
+diff --git a/llvm/cmake/modules/testz3.cpp b/llvm/cmake/modules/testz3.cpp
+new file mode 100644
+index 000000000..2c55ba7d6
+--- /dev/null
++++ b/llvm/cmake/modules/testz3.cpp
+@@ -0,0 +1,8 @@
++#include <assert.h>
++#include <z3.h>
++int main() {
++  unsigned int major, minor, build, rev;
++  Z3_get_version(&major, &minor, &build, &rev);
++  printf("%u.%u.%u", major, minor, build);
++  return 0;
++}

--- a/ports/llvm-12/0007-clang-sys-include-dir-path.patch
+++ b/ports/llvm-12/0007-clang-sys-include-dir-path.patch
@@ -1,0 +1,31 @@
+diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
+index 418e1d3e8ec9..007e6ca5b3a5 100644
+--- a/clang/lib/Driver/Driver.cpp
++++ b/clang/lib/Driver/Driver.cpp
+@@ -108,7 +108,7 @@ std::string Driver::GetResourcesPath(StringRef BinaryPath,
+   // exact same string ("a/../b/" and "b/" get different hashes, for example).
+ 
+   // Dir is bin/ or lib/, depending on where BinaryPath is.
+-  std::string Dir = std::string(llvm::sys::path::parent_path(BinaryPath));
++  std::string Dir = std::string(llvm::sys::path::parent_path(llvm::sys::path::parent_path(BinaryPath)));
+ 
+   SmallString<128> P(Dir);
+   if (CustomResourceDir != "") {
+diff --git a/clang/lib/Driver/ToolChains/Darwin.cpp b/clang/lib/Driver/ToolChains/Darwin.cpp
+index eb7bd4aec898..878a49c3cfb8 100644
+--- a/clang/lib/Driver/ToolChains/Darwin.cpp
++++ b/clang/lib/Driver/ToolChains/Darwin.cpp
+@@ -2052,11 +2052,12 @@ void DarwinClang::AddClangCXXStdlibIncludeArgs(
+     // include_next could break).
+ 
+     // Check for (1)
+-    // Get from '<install>/bin' to '<install>/include/c++/v1'.
++    // Get from '<install>/tools/llvm' to '<install>/include/c++/v1'.
+     // Note that InstallBin can be relative, so we use '..' instead of
+     // parent_path.
+     llvm::SmallString<128> InstallBin =
+         llvm::StringRef(getDriver().getInstalledDir()); // <install>/bin
++    llvm::sys::path::append(InstallBin, "..");
+     llvm::sys::path::append(InstallBin, "..", "include", "c++", "v1");
+     if (getVFS().exists(InstallBin)) {
+       addSystemInclude(DriverArgs, CC1Args, InstallBin);

--- a/ports/llvm-12/CONTROL
+++ b/ports/llvm-12/CONTROL
@@ -1,0 +1,140 @@
+Source: llvm-12
+Version: 12.0.1
+Homepage: https://llvm.org/
+Description: The LLVM Compiler Infrastructure
+Supports: !uwp
+Build-Depends: llvm-vcpkg-common
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+
+Feature: tools
+Description: Build LLVM tools.
+
+Feature: utils
+Description: Build LLVM utils.
+
+Feature: default-targets
+Description: Build with platform-specific default targets
+Build-Depends: llvm-12[core,target-x86] (x86|x64), llvm-12[core,target-arm] (arm&!arm64), llvm-12[core,target-aarch64] (arm64), llvm-12[core,target-all] (!x86&!x64&!arm&!arm64)
+
+Feature: target-all
+Description: Build with all backends.
+Build-Depends: llvm-12[core,target-aarch64,target-amdgpu,target-arm,target-bpf,target-hexagon,target-lanai,target-mips,target-msp430,target-nvptx,target-powerpc,target-riscv,target-sparc,target-systemz,target-webassembly,target-x86,target-xcore]
+
+Feature: target-aarch64
+Description: Build with AArch64 backend.
+
+Feature: target-amdgpu
+Description: Build with AMDGPU backend.
+
+Feature: target-arm
+Description: Build with ARM backend.
+
+Feature: target-avr
+Description: Build with AVR backend.
+
+Feature: target-bpf
+Description: Build with BPF backend.
+
+Feature: target-hexagon
+Description: Build with Hexagon backend.
+
+Feature: target-lanai
+Description: Build with Lanai backend.
+
+Feature: target-mips
+Description: Build with Mips backend.
+
+Feature: target-msp430
+Description: Build with MSP430 backend.
+
+Feature: target-nvptx
+Description: Build with NVPTX backend.
+
+Feature: target-powerpc
+Description: Build with PowerPC backend.
+
+Feature: target-riscv
+Description: Build with RISCV backend.
+
+Feature: target-sparc
+Description: Build with Sparc backend.
+
+Feature: target-systemz
+Description: Build with SystemZ backend.
+
+Feature: target-webassembly
+Description: Build with WebAssembly backend.
+
+Feature: target-x86
+Description: Build with X86 backend.
+
+Feature: target-xcore
+Description: Build with XCore backend.
+
+Feature: enable-rtti
+Description: Build LLVM with run-time type information.
+
+Feature: enable-assertions
+Description: Build LLVM with assertions.
+
+Feature: disable-assertions
+Description: Build LLVM without assertions.
+
+Feature: enable-terminfo
+Description: Build LLVM with linking to terminfo.
+Build-Depends: ncurses
+
+Feature: disable-terminfo
+Description: Build LLVM without linking to terminfo.
+
+Feature: enable-abi-breaking-checks
+Description: Build LLVM with LLVM_ABI_BREAKING_CHECKS=FORCE_ON.
+
+Feature: disable-abi-breaking-checks
+Description: Build LLVM with LLVM_ABI_BREAKING_CHECKS=FORCE_OFF.
+
+Feature: clang
+Description: Build C Language Family Front-end.
+
+Feature: disable-clang-static-analyzer
+Description: Build without static analyzer.
+
+Feature: clang-tools-extra
+Description: Build Clang tools.
+
+Feature: compiler-rt
+Description: Build compiler's runtime libraries.
+
+Feature: flang
+Description: Build Fortran front end.
+Build-Depends: llvm[core,mlir]
+
+Feature: lld
+Description: Build LLVM linker.
+
+Feature: lldb
+Description: Build LLDB debugger.
+
+Feature: mlir
+Description: Build Multi-Level IR Compiler Framework.
+
+Feature: openmp
+Description: Build LLVM OpenMP libraries.
+Build-Depends: llvm[core,utils]
+
+Feature: polly
+Description: Build polyhedral optimizations for LLVM.
+Build-Depends: llvm[core,utils]
+
+Feature: enable-z3
+Description: Compile with Z3 SMT solver support for Clang static analyzer.
+Build-Depends: z3, llvm-12[core,clang]
+
+Feature: libcxx
+Description: Build libcxx runtime
+
+Feature: libcxxabi
+Description: Build libcxxabi runtime
+
+Feature: enable-eh
+Description: Build LLVM with exception handler turned on.

--- a/ports/llvm-12/CONTROL
+++ b/ports/llvm-12/CONTROL
@@ -1,5 +1,5 @@
 Source: llvm-12
-Version: 12.0.1
+Version: 12.0.0-rc2
 Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp

--- a/ports/llvm-12/LICENSE
+++ b/ports/llvm-12/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/ports/llvm-12/NOTICE
+++ b/ports/llvm-12/NOTICE
@@ -1,0 +1,5 @@
+This directory was initially copied from ports/llvm/portfile.cmake
+https://github.com/microsoft/vcpkg/tree/7e3d3beac5ca6fe8aab4599d4e1d8ce270ccdea8
+
+This directory will also contain backports of patches that are found and
+committed to upstream latest LLVM version(s).

--- a/ports/llvm-12/portfile.cmake
+++ b/ports/llvm-12/portfile.cmake
@@ -1,0 +1,21 @@
+set(LLVM_VERSION "12.0.0-rc2")
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO llvm/llvm-project
+    REF llvmorg-${LLVM_VERSION}
+    SHA512 d8f9b3dfeb0fe9b91eb7f49da393784333044db2653373fbb168afd3c8d50f3e3ec7a7b8f44df522d0facafbfe4cfc4d9e2906d19f1e6feb0bdc569b6c10a17d
+    HEAD_REF main
+    PATCHES
+        0001-fix-install-paths.patch
+        0002-fix-openmp-debug.patch
+        0003-fix-dr-1734.patch
+        0004-fix-tools-path.patch
+        0005-remove-FindZ3.cmake.patch
+        0006-fix-FindZ3.cmake.patch
+        0007-clang-sys-include-dir-path.patch
+)
+
+include("${CURRENT_INSTALLED_DIR}/share/llvm-vcpkg-common/llvm-common-build.cmake")

--- a/ports/llvm-9/CONTROL
+++ b/ports/llvm-9/CONTROL
@@ -5,7 +5,7 @@ Homepage: https://llvm.org/
 Description: The LLVM Compiler Infrastructure
 Supports: !uwp
 Build-Depends: llvm-vcpkg-common
-Default-Features: tools, clang, enable-rtti, enable-z3, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
+Default-Features: tools, clang, enable-rtti, enable-z3, enable-eh, enable-assertions, disable-abi-breaking-checks, disable-terminfo, libcxx, libcxxabi, target-aarch64, target-arm, target-nvptx, target-sparc, target-x86
 
 Feature: tools
 Description: Build LLVM tools.
@@ -126,3 +126,6 @@ Description: Build libcxx runtime
 
 Feature: libcxxabi
 Description: Build libcxxabi runtime
+
+Feature: enable-eh
+Description: Build LLVM with exception handler turned on.

--- a/ports/llvm-vcpkg-common/llvm-common-build.cmake
+++ b/ports/llvm-vcpkg-common/llvm-common-build.cmake
@@ -38,6 +38,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     utils LLVM_INCLUDE_UTILS
     enable-rtti LLVM_ENABLE_RTTI
     enable-z3 LLVM_ENABLE_Z3_SOLVER
+    enable-eh LLVM_ENABLE_EH
 )
 
 # Linking with gold is better than /bin/ld


### PR DESCRIPTION
The changes add port files to build llvm 12. It also enables the exception handler which is required to build alive2. 